### PR TITLE
🔒 security: fix insecure P/Invoke declarations by adding CharSet.Unicode

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -330,14 +330,14 @@ namespace Launchbox
         }
 
         // --- WIN32 IMPORTS ---
-        [DllImport("user32.dll")] private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
-        [DllImport("user32.dll")] private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
-        [DllImport("user32.dll")] private static extern bool SetForegroundWindow(IntPtr hWnd);
-        [DllImport("user32.dll")] private static extern bool IsIconic(IntPtr hWnd);
-        [DllImport("user32.dll")] private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
-        [DllImport("user32.dll")] private static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
-        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")] private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, WndProcDelegate dwNewLong);
-        [DllImport("user32.dll", EntryPoint = "SetWindowLong")] private static extern IntPtr SetWindowLong32(IntPtr hWnd, int nIndex, WndProcDelegate dwNewLong);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern bool SetForegroundWindow(IntPtr hWnd);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern bool IsIconic(IntPtr hWnd);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr", CharSet = CharSet.Unicode)] private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, WndProcDelegate dwNewLong);
+        [DllImport("user32.dll", EntryPoint = "SetWindowLong", CharSet = CharSet.Unicode)] private static extern IntPtr SetWindowLong32(IntPtr hWnd, int nIndex, WndProcDelegate dwNewLong);
 
         private static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, WndProcDelegate dwNewLong)
         {
@@ -455,9 +455,9 @@ namespace Launchbox
             }
         }
 
-        [DllImport("user32.dll")] private static extern uint PrivateExtractIcons(string l, int n, int cx, int cy, ref IntPtr p, IntPtr id, uint ni, uint fl);
-        [DllImport("user32.dll")] private static extern bool DestroyIcon(IntPtr hIcon);
-        [DllImport("kernel32.dll")] private static extern int GetPrivateProfileString(string s, string k, string d, System.Text.StringBuilder r, int z, string f);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern uint PrivateExtractIcons(string l, int n, int cx, int cy, ref IntPtr p, IntPtr id, uint ni, uint fl);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern bool DestroyIcon(IntPtr hIcon);
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)] private static extern int GetPrivateProfileString(string s, string k, string d, System.Text.StringBuilder r, int z, string f);
 
         private string GetIniValue(string p, string s, string k)
         {


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Insecure P/Invoke declarations were missing the `CharSet` property in the `DllImport` attribute.

### ⚠️ Risk: The potential impact if left unfixed
When `CharSet` is missing, it defaults to `CharSet.Ansi`. This can lead to:
- **Security risks:** Potential buffer overflows or vulnerabilities in ANSI versions of system APIs that are not present in their Unicode counterparts.
- **Data loss/Incorrect behavior:** Strings containing non-ASCII characters may be incorrectly marshaled, leading to application errors or data corruption.
- **Performance overhead:** Modern Windows APIs are natively Unicode, so using ANSI requires an additional conversion step.

### 🛡️ Solution: How the fix addresses the vulnerability
Added `CharSet = CharSet.Unicode` to all `DllImport` attributes in `MainWindow.xaml.cs`. This forces the use of the Unicode (`W`) variants of Windows APIs and ensures that strings are marshaled as UTF-16, which is the standard for both .NET and modern Windows.

---
*PR created automatically by Jules for task [17794452705993937278](https://jules.google.com/task/17794452705993937278) started by @mikekthx*