### PR TITLE
🧹 Refactor: Extract Helper Classes AppItem and SimpleCommand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ settings["Key"] = value;
 ## Common Tasks
 
 ### Add app item property
-1. Add to `AppItem` class in `MainWindow.xaml.cs:462`
+1. Add to `AppItem` class in `AppItem.cs`
 2. Populate in `LoadAppsAsync()` at line ~340
 3. Update XAML DataTemplate if needed
 

--- a/AppItem.cs
+++ b/AppItem.cs
@@ -1,0 +1,10 @@
+using Microsoft.UI.Xaml.Media.Imaging;
+
+namespace Launchbox;
+
+public class AppItem
+{
+    public string Name { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public BitmapImage? Icon { get; set; }
+}

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -467,20 +467,4 @@ namespace Launchbox
         }
     }
 
-    // --- HELPER CLASSES ---
-    public class AppItem
-    {
-        public string Name { get; set; } = string.Empty;
-        public string Path { get; set; } = string.Empty;
-        public BitmapImage? Icon { get; set; }
-    }
-
-    public class SimpleCommand : System.Windows.Input.ICommand
-    {
-        private readonly Action _action;
-        public SimpleCommand(Action action) => _action = action;
-        public bool CanExecute(object? parameter) => true;
-        public void Execute(object? parameter) => _action();
-        public event EventHandler? CanExecuteChanged { add { } remove { } }
-    }
 }

--- a/SimpleCommand.cs
+++ b/SimpleCommand.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Windows.Input;
+
+namespace Launchbox;
+
+public class SimpleCommand : ICommand
+{
+    private readonly Action _action;
+    public SimpleCommand(Action action) => _action = action;
+    public bool CanExecute(object? parameter) => true;
+    public void Execute(object? parameter) => _action();
+    public event EventHandler? CanExecuteChanged { add { } remove { } }
+}


### PR DESCRIPTION
This PR refactors `MainWindow.xaml.cs` by extracting two helper classes, `AppItem` and `SimpleCommand`, into their own files. This improves the readability of `MainWindow.xaml.cs` and follows the one-class-per-file convention.

🎯 **What:**
- Created `AppItem.cs` and moved the `AppItem` class there.
- Created `SimpleCommand.cs` and moved the `SimpleCommand` class there.
- Removed these classes from `MainWindow.xaml.cs`.
- Updated `AGENTS.md` to point to the new location of `AppItem`.

💡 **Why:**
- Improves maintainability and organization by reducing the length of `MainWindow.xaml.cs`.
- Adheres to the coding convention of one class per file.

✅ **Verification:**
- Verified that the new files have the correct `using` statements and namespaces.
- Ran `dotnet build` with `-p:EnableWindowsTargeting=true`. While the full build failed due to the XAML compiler being Windows-only, the C# compilation confirmed that the types are correctly found and there are no missing reference errors for these classes.

✨ **Result:**
- Cleaner `MainWindow.xaml.cs`.
- Better organized project structure.

---
*PR created automatically by Jules for task [16949930451291256174](https://jules.google.com/task/16949930451291256174) started by @mikekthx*