### PR TITLE
Improve testing for LoadAppsAsync by extracting ShortcutService

### DIFF
--- a/FileSystem.cs
+++ b/FileSystem.cs
@@ -1,0 +1,9 @@
+using System.IO;
+
+namespace Launchbox;
+
+public class FileSystem : IFileSystem
+{
+    public bool DirectoryExists(string path) => Directory.Exists(path);
+    public string[] GetFiles(string path) => Directory.GetFiles(path);
+}

--- a/IFileSystem.cs
+++ b/IFileSystem.cs
@@ -1,0 +1,7 @@
+namespace Launchbox;
+
+public interface IFileSystem
+{
+    bool DirectoryExists(string path);
+    string[] GetFiles(string path);
+}

--- a/Launchbox.Tests/Launchbox.Tests.csproj
+++ b/Launchbox.Tests/Launchbox.Tests.csproj
@@ -21,6 +21,8 @@
     <Compile Include="..\WindowPositionManager.cs" Link="WindowPositionManager.cs" />
     <Compile Include="..\IVisualTreeService.cs" Link="IVisualTreeService.cs" />
     <Compile Include="..\VisualTreeFinder.cs" Link="VisualTreeFinder.cs" />
+    <Compile Include="..\IFileSystem.cs" Link="IFileSystem.cs" />
+    <Compile Include="..\ShortcutService.cs" Link="ShortcutService.cs" />
   </ItemGroup>
 
 </Project>

--- a/Launchbox.Tests/ShortcutServiceTests.cs
+++ b/Launchbox.Tests/ShortcutServiceTests.cs
@@ -1,0 +1,79 @@
+using Xunit;
+using Launchbox;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System;
+
+namespace Launchbox.Tests;
+
+public class MockFileSystem : IFileSystem
+{
+    private readonly HashSet<string> _directories = new();
+    private readonly Dictionary<string, List<string>> _files = new();
+
+    public void AddDirectory(string path)
+    {
+        _directories.Add(path);
+    }
+
+    public void AddFile(string directory, string filename)
+    {
+        if (!_files.ContainsKey(directory))
+        {
+            _files[directory] = new List<string>();
+        }
+        _files[directory].Add(Path.Combine(directory, filename));
+    }
+
+    public bool DirectoryExists(string path)
+    {
+        return _directories.Contains(path);
+    }
+
+    public string[] GetFiles(string path)
+    {
+        if (_files.TryGetValue(path, out var files))
+        {
+            return files.ToArray();
+        }
+        return Array.Empty<string>();
+    }
+}
+
+public class ShortcutServiceTests
+{
+    private readonly string SHORTCUT_FOLDER = Path.Combine("Shortcuts");
+    private readonly string[] ALLOWED_EXTENSIONS = { ".lnk", ".url" };
+
+    [Fact]
+    public void GetShortcutFiles_ReturnsNull_WhenDirectoryDoesNotExist()
+    {
+        var mockFileSystem = new MockFileSystem();
+        var service = new ShortcutService(mockFileSystem);
+
+        var result = service.GetShortcutFiles(SHORTCUT_FOLDER, ALLOWED_EXTENSIONS);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetShortcutFiles_ReturnsFilteredFiles_WhenDirectoryExists()
+    {
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.AddDirectory(SHORTCUT_FOLDER);
+        mockFileSystem.AddFile(SHORTCUT_FOLDER, "App1.lnk");
+        mockFileSystem.AddFile(SHORTCUT_FOLDER, "App2.url");
+        mockFileSystem.AddFile(SHORTCUT_FOLDER, "App3.txt"); // Should be filtered out
+
+        var service = new ShortcutService(mockFileSystem);
+
+        var result = service.GetShortcutFiles(SHORTCUT_FOLDER, ALLOWED_EXTENSIONS);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Length);
+        Assert.Contains(result, f => f.EndsWith("App1.lnk"));
+        Assert.Contains(result, f => f.EndsWith("App2.url"));
+        Assert.DoesNotContain(result, f => f.EndsWith("App3.txt"));
+    }
+}

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class MainWindow : Window
     private bool _hasPositioned = false;
     private ScrollViewer? _internalScrollViewer;
     private readonly WindowPositionManager _windowPositionManager;
+    private readonly ShortcutService _shortcutService;
 
     // Window dragging state
     private bool _isDraggingWindow = false;
@@ -45,6 +46,7 @@ public sealed partial class MainWindow : Window
         this.InitializeComponent();
 
         _windowPositionManager = new WindowPositionManager(new LocalSettingsStore());
+        _shortcutService = new ShortcutService(new FileSystem());
 
         ToggleWindowCommand = new SimpleCommand(ToggleWindowVisibility);
         ExitCommand = new SimpleCommand(ExitApplication);
@@ -309,14 +311,7 @@ public sealed partial class MainWindow : Window
         // --- APP LOADING ---
         private async Task LoadAppsAsync()
         {
-            var files = await Task.Run(() =>
-            {
-                if (!Directory.Exists(_shortcutFolder)) return null;
-                return Directory.GetFiles(_shortcutFolder)
-                    .Where(f => ALLOWED_EXTENSIONS.Contains(Path.GetExtension(f).ToLowerInvariant()))
-                    .OrderBy(f => Path.GetFileName(f))
-                    .ToArray();
-            });
+            var files = await Task.Run(() => _shortcutService.GetShortcutFiles(_shortcutFolder, ALLOWED_EXTENSIONS));
 
             if (files == null)
             {

--- a/ShortcutService.cs
+++ b/ShortcutService.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Launchbox;
+
+public class ShortcutService
+{
+    private readonly IFileSystem _fileSystem;
+
+    public ShortcutService(IFileSystem fileSystem)
+    {
+        _fileSystem = fileSystem;
+    }
+
+    public string[]? GetShortcutFiles(string folderPath, string[] allowedExtensions)
+    {
+        if (!_fileSystem.DirectoryExists(folderPath))
+        {
+            return null;
+        }
+
+        return _fileSystem.GetFiles(folderPath)
+            .Where(f => allowedExtensions.Contains(Path.GetExtension(f).ToLowerInvariant()))
+            .OrderBy(f => Path.GetFileName(f))
+            .ToArray();
+    }
+}


### PR DESCRIPTION
This change improves testability of the app loading process by extracting file system dependencies. It introduces `IFileSystem` and `ShortcutService` to allow mocking of file system operations. Unit tests were added to verify the behavior when the shortcut folder is missing and when it contains valid/invalid files. This addresses the testing gap identified in `MainWindow.xaml.cs`.

---
*PR created automatically by Jules for task [1954533041503620472](https://jules.google.com/task/1954533041503620472) started by @mikekthx*