### PR TITLE
🧪 Refactor Icon Extraction for Testability

### DIFF
--- a/FileSystem.cs
+++ b/FileSystem.cs
@@ -1,9 +1,22 @@
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Launchbox;
 
 public class FileSystem : IFileSystem
 {
     public bool DirectoryExists(string path) => Directory.Exists(path);
+    public bool FileExists(string path) => File.Exists(path);
     public string[] GetFiles(string path) => Directory.GetFiles(path);
+
+    public string GetIniValue(string path, string section, string key)
+    {
+        var sb = new StringBuilder(255);
+        GetPrivateProfileString(section, key, "", sb, 255, path);
+        return sb.ToString();
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetPrivateProfileString(string s, string k, string d, StringBuilder r, int z, string f);
 }

--- a/IFileSystem.cs
+++ b/IFileSystem.cs
@@ -3,5 +3,7 @@ namespace Launchbox;
 public interface IFileSystem
 {
     bool DirectoryExists(string path);
+    bool FileExists(string path);
     string[] GetFiles(string path);
+    string GetIniValue(string path, string section, string key);
 }

--- a/IconHelper.cs
+++ b/IconHelper.cs
@@ -1,49 +1,13 @@
 using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Diagnostics;
-using System.Drawing.Imaging;
-using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Windows.Storage.Streams;
-using WinIcon = System.Drawing.Icon;
 
 namespace Launchbox;
 
 public static class IconHelper
 {
-    public static byte[]? ExtractIconBytes(string path)
-    {
-        IntPtr hIcon = IntPtr.Zero;
-        try
-        {
-            if (path.EndsWith(".url", StringComparison.OrdinalIgnoreCase))
-            {
-                string iconFile = GetIniValue(path, "InternetShortcut", "IconFile");
-                if (File.Exists(iconFile)) path = iconFile;
-            }
-
-            PrivateExtractIcons(path, 0, 128, 128, ref hIcon, IntPtr.Zero, 1, 0);
-            if (hIcon == IntPtr.Zero) return null;
-
-            using var icon = WinIcon.FromHandle(hIcon);
-            using var bmp = icon.ToBitmap();
-            using var ms = new MemoryStream();
-            bmp.Save(ms, ImageFormat.Png);
-            return ms.ToArray();
-        }
-        catch (Exception ex)
-        {
-            Trace.WriteLine($"Failed to extract icon for {path}: {ex.Message}");
-            return null;
-        }
-        finally
-        {
-            if (hIcon != IntPtr.Zero)
-                DestroyIcon(hIcon);
-        }
-    }
-
     public static async Task<BitmapImage?> CreateBitmapImageAsync(byte[] imageBytes)
     {
         try
@@ -63,16 +27,4 @@ public static class IconHelper
             return null;
         }
     }
-
-    private static string GetIniValue(string p, string s, string k)
-    {
-        var sb = new System.Text.StringBuilder(255);
-        GetPrivateProfileString(s, k, "", sb, 255, p);
-        return sb.ToString();
-    }
-
-    // --- WIN32 IMPORTS ---
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern uint PrivateExtractIcons(string l, int n, int cx, int cy, ref IntPtr p, IntPtr id, uint ni, uint fl);
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern bool DestroyIcon(IntPtr hIcon);
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)] private static extern int GetPrivateProfileString(string s, string k, string d, System.Text.StringBuilder r, int z, string f);
 }

--- a/IconService.cs
+++ b/IconService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+using WinIcon = System.Drawing.Icon;
+
+namespace Launchbox;
+
+public class IconService
+{
+    private readonly IFileSystem _fileSystem;
+
+    public IconService(IFileSystem fileSystem)
+    {
+        _fileSystem = fileSystem;
+    }
+
+    public string ResolveIconPath(string path)
+    {
+        if (path.EndsWith(".url", StringComparison.OrdinalIgnoreCase))
+        {
+            string iconFile = _fileSystem.GetIniValue(path, "InternetShortcut", "IconFile");
+            if (_fileSystem.FileExists(iconFile))
+            {
+                return iconFile;
+            }
+        }
+        return path;
+    }
+
+    public byte[]? ExtractIconBytes(string path)
+    {
+        IntPtr hIcon = IntPtr.Zero;
+        string resolvedPath = path;
+
+        try
+        {
+            resolvedPath = ResolveIconPath(path);
+
+            PrivateExtractIcons(resolvedPath, 0, 128, 128, ref hIcon, IntPtr.Zero, 1, 0);
+            if (hIcon == IntPtr.Zero) return null;
+
+            using var icon = WinIcon.FromHandle(hIcon);
+            using var bmp = icon.ToBitmap();
+            using var ms = new MemoryStream();
+            bmp.Save(ms, ImageFormat.Png);
+            return ms.ToArray();
+        }
+        catch (Exception ex)
+        {
+            Trace.WriteLine($"Failed to extract icon for {path} (resolved: {resolvedPath}): {ex.Message}");
+            return null;
+        }
+        finally
+        {
+            if (hIcon != IntPtr.Zero)
+                DestroyIcon(hIcon);
+        }
+    }
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern uint PrivateExtractIcons(string l, int n, int cx, int cy, ref IntPtr p, IntPtr id, uint ni, uint fl);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern bool DestroyIcon(IntPtr hIcon);
+}

--- a/Launchbox.Tests/IconServiceTests.cs
+++ b/Launchbox.Tests/IconServiceTests.cs
@@ -1,0 +1,64 @@
+using Xunit;
+using Launchbox;
+using System.IO;
+
+namespace Launchbox.Tests;
+
+public class IconServiceTests
+{
+    private readonly MockFileSystem _mockFileSystem;
+    private readonly IconService _iconService;
+
+    public IconServiceTests()
+    {
+        _mockFileSystem = new MockFileSystem();
+        _iconService = new IconService(_mockFileSystem);
+    }
+
+    [Fact]
+    public void ResolveIconPath_ReturnsOriginalPath_WhenNotUrlFile()
+    {
+        string path = Path.Combine("C:", "Shortcuts", "App.lnk");
+        string result = _iconService.ResolveIconPath(path);
+        Assert.Equal(path, result);
+    }
+
+    [Fact]
+    public void ResolveIconPath_ReturnsOriginalPath_WhenUrlFileHasNoIconFile()
+    {
+        string path = Path.Combine("C:", "Shortcuts", "App.url");
+        _mockFileSystem.AddFile(path);
+        // No INI value set
+
+        string result = _iconService.ResolveIconPath(path);
+        Assert.Equal(path, result);
+    }
+
+    [Fact]
+    public void ResolveIconPath_ReturnsIconPath_WhenUrlFileHasValidIconFile()
+    {
+        string path = Path.Combine("C:", "Shortcuts", "App.url");
+        string iconPath = Path.Combine("C:", "Icons", "App.ico");
+
+        _mockFileSystem.AddFile(path);
+        _mockFileSystem.AddFile(iconPath);
+        _mockFileSystem.SetIniValue(path, "InternetShortcut", "IconFile", iconPath);
+
+        string result = _iconService.ResolveIconPath(path);
+        Assert.Equal(iconPath, result);
+    }
+
+    [Fact]
+    public void ResolveIconPath_ReturnsOriginalPath_WhenIconFileDoesNotExist()
+    {
+        string path = Path.Combine("C:", "Shortcuts", "App.url");
+        string iconPath = Path.Combine("C:", "Icons", "App.ico");
+
+        _mockFileSystem.AddFile(path);
+        // iconPath is NOT added to file system
+        _mockFileSystem.SetIniValue(path, "InternetShortcut", "IconFile", iconPath);
+
+        string result = _iconService.ResolveIconPath(path);
+        Assert.Equal(path, result);
+    }
+}

--- a/Launchbox.Tests/Launchbox.Tests.csproj
+++ b/Launchbox.Tests/Launchbox.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="xunit" Version="2.6.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,6 +24,7 @@
     <Compile Include="..\VisualTreeFinder.cs" Link="VisualTreeFinder.cs" />
     <Compile Include="..\IFileSystem.cs" Link="IFileSystem.cs" />
     <Compile Include="..\ShortcutService.cs" Link="ShortcutService.cs" />
+    <Compile Include="..\IconService.cs" Link="IconService.cs" />
   </ItemGroup>
 
 </Project>

--- a/Launchbox.Tests/MockFileSystem.cs
+++ b/Launchbox.Tests/MockFileSystem.cs
@@ -1,0 +1,71 @@
+using Launchbox;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Launchbox.Tests;
+
+public class MockFileSystem : IFileSystem
+{
+    private readonly HashSet<string> _directories = new();
+    private readonly Dictionary<string, List<string>> _files = new();
+    private readonly Dictionary<string, string> _iniValues = new();
+
+    public void AddDirectory(string path)
+    {
+        _directories.Add(path);
+    }
+
+    public void AddFile(string directory, string filename)
+    {
+        if (!_files.ContainsKey(directory))
+        {
+            _files[directory] = new List<string>();
+        }
+        _files[directory].Add(Path.Combine(directory, filename));
+    }
+
+    public void AddFile(string fullPath)
+    {
+        string? directory = Path.GetDirectoryName(fullPath);
+        if (string.IsNullOrEmpty(directory)) return;
+
+        if (!_files.ContainsKey(directory))
+        {
+            _files[directory] = new List<string>();
+        }
+        _files[directory].Add(fullPath);
+    }
+
+    public void SetIniValue(string path, string section, string key, string value)
+    {
+        _iniValues[$"{path}|{section}|{key}"] = value;
+    }
+
+    public bool DirectoryExists(string path)
+    {
+        return _directories.Contains(path);
+    }
+
+    public bool FileExists(string path)
+    {
+        return _files.Values.Any(list => list.Contains(path));
+    }
+
+    public string[] GetFiles(string path)
+    {
+        if (_files.TryGetValue(path, out var files))
+        {
+            return files.ToArray();
+        }
+        return Array.Empty<string>();
+    }
+
+    public string GetIniValue(string path, string section, string key)
+    {
+        if (_iniValues.TryGetValue($"{path}|{section}|{key}", out var val))
+            return val;
+        return "";
+    }
+}

--- a/Launchbox.Tests/ShortcutServiceTests.cs
+++ b/Launchbox.Tests/ShortcutServiceTests.cs
@@ -7,40 +7,6 @@ using System;
 
 namespace Launchbox.Tests;
 
-public class MockFileSystem : IFileSystem
-{
-    private readonly HashSet<string> _directories = new();
-    private readonly Dictionary<string, List<string>> _files = new();
-
-    public void AddDirectory(string path)
-    {
-        _directories.Add(path);
-    }
-
-    public void AddFile(string directory, string filename)
-    {
-        if (!_files.ContainsKey(directory))
-        {
-            _files[directory] = new List<string>();
-        }
-        _files[directory].Add(Path.Combine(directory, filename));
-    }
-
-    public bool DirectoryExists(string path)
-    {
-        return _directories.Contains(path);
-    }
-
-    public string[] GetFiles(string path)
-    {
-        if (_files.TryGetValue(path, out var files))
-        {
-            return files.ToArray();
-        }
-        return Array.Empty<string>();
-    }
-}
-
 public class ShortcutServiceTests
 {
     private readonly string SHORTCUT_FOLDER = Path.Combine("Shortcuts");

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -31,6 +31,7 @@ public sealed partial class MainWindow : Window
     private ScrollViewer? _internalScrollViewer;
     private readonly WindowPositionManager _windowPositionManager;
     private readonly ShortcutService _shortcutService;
+    private readonly IconService _iconService;
 
     // Window dragging state
     private bool _isDraggingWindow = false;
@@ -46,7 +47,9 @@ public sealed partial class MainWindow : Window
         this.InitializeComponent();
 
         _windowPositionManager = new WindowPositionManager(new LocalSettingsStore());
-        _shortcutService = new ShortcutService(new FileSystem());
+        var fileSystem = new FileSystem();
+        _shortcutService = new ShortcutService(fileSystem);
+        _iconService = new IconService(fileSystem);
 
         ToggleWindowCommand = new SimpleCommand(ToggleWindowVisibility);
         ExitCommand = new SimpleCommand(ExitApplication);
@@ -329,7 +332,7 @@ public sealed partial class MainWindow : Window
 
                     _ = Task.Run(() =>
                     {
-                        var iconBytes = IconHelper.ExtractIconBytes(file);
+                        var iconBytes = _iconService.ExtractIconBytes(file);
                         if (iconBytes != null)
                         {
                             this.DispatcherQueue.TryEnqueue(async () =>


### PR DESCRIPTION
This PR refactors the icon extraction logic, specifically the handling of `.url` files, into a testable `IconService`. 

**Changes:**
1.  **`IFileSystem` / `FileSystem`**: Added `FileExists` and `GetIniValue` (wrapping `GetPrivateProfileString`) to allow mocking of these operations.
2.  **`IconService`**: Created a new service that handles resolving the icon path from a file path (including parsing `.url` files) and extracting the icon bytes.
3.  **`IconHelper`**: Reduced to a static helper for `CreateBitmapImageAsync` as it deals with UI objects.
4.  **Tests**: 
    -   Extracted `MockFileSystem` to its own file and enhanced it to mock INI values and file existence.
    -   Added `IconServiceTests` to verify `ResolveIconPath` logic for various scenarios (normal files, valid/invalid .url files).
5.  **`MainWindow`**: Updated to inject `IconService` and use it for loading icons.

**Coverage:**
-   Verified `ResolveIconPath` correctly handles `.url` files by reading the `IconFile` from `InternetShortcut` section.
-   Verified fallback to original path if icon file doesn't exist or is not specified.
-   Existing `ShortcutServiceTests` continue to pass with the updated `MockFileSystem`.

---
*PR created automatically by Jules for task [1274270467997305047](https://jules.google.com/task/1274270467997305047) started by @mikekthx*