### PR TITLE
🎨 Palette: Add empty state for when no shortcuts are found

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-23 - App Item Accessibility
 **Learning:** `AppItem` DataTemplates use a `StackPanel` container that lacks default accessibility properties.
 **Action:** Always add `ToolTipService.ToolTip` and `AutomationProperties.Name` to the root container of DataTemplates for list items to ensure truncation is readable and screen readers have context.
+
+## 2025-05-24 - WinUI 3 Window Resources
+**Learning:** The `Window` class in WinUI 3 (Windows App SDK) does not expose a `Resources` property in XAML like WPF or UWP `Page`/`UserControl`.
+**Action:** Define window-scoped resources within the root layout element (e.g., `<Grid.Resources>`) instead of `<Window.Resources>`.

--- a/Helpers/BooleanToVisibilityConverter.cs
+++ b/Helpers/BooleanToVisibilityConverter.cs
@@ -1,0 +1,25 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+using System;
+
+namespace Launchbox.Helpers;
+
+public class BooleanToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        bool isVisible = value is bool b && b;
+
+        if (parameter is string paramString && paramString.Equals("Invert", StringComparison.OrdinalIgnoreCase))
+        {
+            isVisible = !isVisible;
+        }
+
+        return isVisible ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Launchbox.Tests/MainViewModelTests.cs
+++ b/Launchbox.Tests/MainViewModelTests.cs
@@ -98,6 +98,28 @@ public class MainViewModelTests
         Assert.Equal("C:\\Test.lnk", _appLauncher.LastLaunchedPath);
     }
 
+    [Fact]
+    public async Task LoadAppsAsync_SetsIsEmptyToTrue_WhenNoAppsFound()
+    {
+        var viewModel = CreateViewModel();
+
+        await viewModel.LoadAppsAsync();
+
+        Assert.True(viewModel.IsEmpty);
+    }
+
+    [Fact]
+    public async Task LoadAppsAsync_SetsIsEmptyToFalse_WhenAppsFound()
+    {
+        string appPath = Path.Combine(_shortcutFolder, "MyApp.lnk");
+        _fileSystem.AddFile(appPath);
+        var viewModel = CreateViewModel();
+
+        await viewModel.LoadAppsAsync();
+
+        Assert.False(viewModel.IsEmpty);
+    }
+
     private MainViewModel CreateViewModel()
     {
         return new MainViewModel(

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Launchbox"
+    xmlns:helpers="using:Launchbox.Helpers"
     xmlns:models="using:Launchbox.Models"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -10,6 +11,9 @@
     mc:Ignorable="d">
 
     <Grid x:Name="RootGrid" Background="Transparent">
+        <Grid.Resources>
+            <helpers:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        </Grid.Resources>
 
         <tb:TaskbarIcon x:Name="TrayIcon"
                         ToolTipText="Launchbox (Alt+S)"
@@ -25,6 +29,24 @@
                 </MenuFlyout>
             </tb:TaskbarIcon.ContextFlyout>
         </tb:TaskbarIcon>
+
+        <StackPanel HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Spacing="12"
+                    Visibility="{x:Bind ViewModel.IsEmpty, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <SymbolIcon Symbol="Folder" RenderTransformOrigin="0.5,0.5">
+                <SymbolIcon.RenderTransform>
+                    <ScaleTransform ScaleX="2" ScaleY="2"/>
+                </SymbolIcon.RenderTransform>
+            </SymbolIcon>
+            <TextBlock Text="No shortcuts found"
+                       FontSize="16"
+                       FontWeight="SemiBold"
+                       HorizontalAlignment="Center"/>
+            <TextBlock Text="Add shortcuts to your Desktop/Shortcuts folder"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                       HorizontalAlignment="Center"/>
+        </StackPanel>
 
         <GridView x:Name="AppGrid" 
                   Padding="20"

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -9,10 +9,12 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Launchbox.ViewModels;
 
-public class MainViewModel
+public class MainViewModel : INotifyPropertyChanged
 {
     private readonly ShortcutService _shortcutService;
     private readonly IconService _iconService;
@@ -22,6 +24,20 @@ public class MainViewModel
     private readonly string _shortcutFolder;
 
     public ObservableCollection<AppItem> Apps { get; } = new();
+
+    private bool _isEmpty;
+    public bool IsEmpty
+    {
+        get => _isEmpty;
+        private set
+        {
+            if (_isEmpty != value)
+            {
+                _isEmpty = value;
+                OnPropertyChanged();
+            }
+        }
+    }
 
     public ICommand LoadAppsCommand { get; }
     public ICommand LaunchAppCommand { get; }
@@ -74,6 +90,7 @@ public class MainViewModel
         {
              Apps.Clear();
              foreach(var item in localAppItems) Apps.Add(item);
+             IsEmpty = Apps.Count == 0;
              return Task.CompletedTask;
         });
 
@@ -104,5 +121,12 @@ public class MainViewModel
         {
             _appLauncher.Launch(app.Path);
         }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }


### PR DESCRIPTION
💡 What: Added an empty state to the main view when no shortcuts are found.
🎯 Why: Users would see a blank screen if no shortcuts were present, which is confusing. This provides clear instructions.
📸 Before/After: Added a centered "No shortcuts found" message with a folder icon.
♿ Accessibility: The empty state text is readable and provides context. The icon is decorative.

---
*PR created automatically by Jules for task [15173252481062386418](https://jules.google.com/task/15173252481062386418) started by @mikekthx*