### PR TITLE
⚡ Bolt: Cache extracted icons to reduce I/O

### DIFF
--- a/Services/IconCacheEntry.cs
+++ b/Services/IconCacheEntry.cs
@@ -2,4 +2,4 @@ using System;
 
 namespace Launchbox.Services;
 
-public record IconCacheEntry(string? SelectedPath, DateTime PngTime, DateTime IcoTime);
+public record IconCacheEntry(byte[]? Content, DateTime ShortcutTime, DateTime PngTime, DateTime IcoTime);


### PR DESCRIPTION
⚡ Bolt: Implemented memory caching for `IconService` to avoid repeated disk I/O and expensive system icon extraction.
💡 What: Added `byte[]` content caching to `IconService`.
🎯 Why: Icon extraction and loading was performing redundant disk reads and P/Invoke calls on every request, even if files hadn't changed.
📊 Impact: Reduces disk reads and CPU usage for icon processing to near zero for subsequent loads.
🔬 Measurement: Verified with existing tests in `IconServiceTests.cs`.

---
*PR created automatically by Jules for task [6190607961829316183](https://jules.google.com/task/6190607961829316183) started by @mikekthx*