### PR TITLE
🛡️ Sentinel: Fix UNC path bypass vulnerability in IconService

### DIFF
--- a/Launchbox.Tests/IconServiceSecurityTests.cs
+++ b/Launchbox.Tests/IconServiceSecurityTests.cs
@@ -19,6 +19,7 @@ public class IconServiceSecurityTests
     [InlineData(@"\\attacker\share\icon.ico")]
     [InlineData(@"\\?\UNC\attacker\share\icon.ico")]
     [InlineData(@"//attacker/share/icon.ico")]
+    [InlineData(@"\??\UNC\attacker\share\icon.ico")]
     public void ResolveIconPath_IgnoresUnsafePaths(string unsafePath)
     {
         // Arrange
@@ -28,10 +29,10 @@ public class IconServiceSecurityTests
         _mockFileSystem.AddFile(urlPath);
         _mockFileSystem.SetIniValue(urlPath, "InternetShortcut", "IconFile", unsafePath);
 
-        // Even if we mock the unsafe file existing (which mimics a real scenario where the share is accessible)
-        // _mockFileSystem.AddFile(unsafePath); // Note: MockFileSystem might struggle with UNC paths, but let's assume it can store strings.
-        // Actually, let's NOT add it to the file system to prove that ResolveIconPath doesn't even try to check it?
-        // No, the vulnerability is checking it. But we want to assert the return value is the ORIGINAL path.
+        // We mock the unsafe file existing to simulate that the attacker's share is accessible.
+        // If the security check is bypassed, ResolveIconPath will find this file and return unsafePath.
+        // If the security check works, it should ignore this file and return urlPath.
+        _mockFileSystem.AddFile(unsafePath);
 
         // Act
         string result = _iconService.ResolveIconPath(urlPath);

--- a/Services/IconService.cs
+++ b/Services/IconService.cs
@@ -43,6 +43,9 @@ public class IconService
     {
         if (string.IsNullOrWhiteSpace(path)) return false;
 
+        // Check for NT object path prefix (\??\) which can bypass UNC checks
+        if (path.StartsWith(@"\??\", StringComparison.OrdinalIgnoreCase)) return true;
+
         // Check for specific UNC patterns
         if (path.StartsWith(@"\\?\UNC", StringComparison.OrdinalIgnoreCase)) return true;
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix UNC path bypass vulnerability

🚨 Severity: HIGH
💡 Vulnerability: `IconService` failed to block UNC paths starting with the NT Object Manager prefix `\??\` (e.g., `\??\UNC\attacker\share\icon.ico`). This could allow malicious `.url` files to trigger NTLM authentication to an attacker-controlled server, leaking the user's NTLM hash.
🎯 Impact: An attacker could capture NTLM hashes by convincing a user to add a malicious `.url` file to their shortcuts folder.
🔧 Fix: Updated `IconService.IsUnsafePath` to explicitly detect and block paths starting with `\??\`.
✅ Verification: Added a new test case to `IconServiceSecurityTests` that uses a `\??\` path. Confirmed that the test fails without the fix and passes with it. Also improved existing tests to properly mock file existence, ensuring the security check is actually exercised.

---
*PR created automatically by Jules for task [17188838706053108914](https://jules.google.com/task/17188838706053108914) started by @mikekthx*