### PR TITLE
🛡️ Sentinel: Fix UNC path injection via mixed slashes

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-01-14 - Mixed Slash UNC Paths
+**Vulnerability:** `IconService.IsUnsafePath` relied on checking `\\` and `//` but missed mixed-slash UNC paths (e.g., `/\attacker` or `\/attacker`), which Windows APIs treat as valid UNC paths, potentially leading to NTLM credential theft.
+**Learning:** `Uri.IsUnc` behavior differs across platforms (Linux vs Windows). On Linux, `Uri` correctly flags `/\` as UNC, but on Windows, it might throw or fail to detect it if malformed, requiring explicit string checks for robust security.
+**Prevention:** Always normalize paths using `Path.GetFullPath` before security checks, and explicitly check for all UNC start patterns (`\\`, `//`, `/\`, `\/`) when dealing with Windows file paths.

--- a/Launchbox.Tests/IconServiceSecurityTests.cs
+++ b/Launchbox.Tests/IconServiceSecurityTests.cs
@@ -20,6 +20,8 @@ public class IconServiceSecurityTests
     [InlineData(@"\\?\UNC\attacker\share\icon.ico")]
     [InlineData(@"//attacker/share/icon.ico")]
     [InlineData(@"\??\UNC\attacker\share\icon.ico")]
+    [InlineData(@"/\attacker/share/icon.ico")]
+    [InlineData(@"\/attacker/share/icon.ico")]
     public void ResolveIconPath_IgnoresUnsafePaths(string unsafePath)
     {
         // Arrange

--- a/Services/IconService.cs
+++ b/Services/IconService.cs
@@ -66,6 +66,18 @@ public class IconService
         // Check for standard UNC paths
         if (path.StartsWith(@"\\") || path.StartsWith("//")) return true;
 
+        // Check for mixed slash UNC paths (e.g. /\server/share or \/server/share)
+        if (path.StartsWith(@"/\") || path.StartsWith(@"\/")) return true;
+
+        // Check normalized path for hidden UNC (Defense in depth)
+        try
+        {
+            string fullPath = Path.GetFullPath(path);
+            if (fullPath.StartsWith(@"\\") || fullPath.StartsWith("//")) return true;
+            if (new Uri(fullPath).IsUnc) return true;
+        }
+        catch { }
+
         // Check using Uri as a backup
         try
         {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix potential UNC path injection via mixed slashes

**Vulnerability:** The `IsUnsafePath` check in `IconService` only blocked paths starting with `\\` or `//`. Windows file APIs often treat mixed slashes (e.g., `/\attacker/share`) as valid UNC paths, which could be used to leak NTLM credentials by tricking the application into accessing a remote SMB share.

**Impact:** An attacker could craft a `.url` file pointing to a malicious SMB share, causing the victim's machine to authenticate to the attacker's server and leak the NTLM hash.

**Fix:**
- Explicitly block paths starting with `/\` and `\/`.
- Added a `Path.GetFullPath` check to normalize the path and detect hidden UNC prefixes.
- Wrapped checks in try-catch to prevent crashes on invalid paths (failing open for invalid paths is generally safe here as file access would fail, but we fail closed for *detected* unsafe paths).

**Verification:** Added unit tests covering `/\` and `\/` scenarios in `IconServiceSecurityTests.cs`.

---
*PR created automatically by Jules for task [4350147628943919796](https://jules.google.com/task/4350147628943919796) started by @mikekthx*