### PR TITLE
⚡ Bolt: Optimize IconHelper image creation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-01-14 - WinRT Stream Optimization
+**Learning:** `InMemoryRandomAccessStream` coupled with `DataWriter` incurs unnecessary double-copying and overhead when wrapping an existing `byte[]`.
+**Action:** Use `System.IO.MemoryStream` (wrapping the byte array) combined with the `.AsRandomAccessStream()` extension method for significantly faster and lighter stream creation when feeding `BitmapImage.SetSourceAsync`.

--- a/Helpers/IconHelper.cs
+++ b/Helpers/IconHelper.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 using Windows.Storage.Streams;
 
@@ -13,12 +14,8 @@ public static class IconHelper
         try
         {
             var image = new BitmapImage();
-            using var stream = new InMemoryRandomAccessStream();
-            using var writer = new DataWriter(stream.GetOutputStreamAt(0));
-            writer.WriteBytes(imageBytes);
-            await writer.StoreAsync();
-            stream.Seek(0);
-            await image.SetSourceAsync(stream);
+            using var stream = new MemoryStream(imageBytes);
+            await image.SetSourceAsync(stream.AsRandomAccessStream());
             return image;
         }
         catch (Exception ex)


### PR DESCRIPTION
💡 What: Replaced `InMemoryRandomAccessStream` + `DataWriter` usage with `MemoryStream` + `.AsRandomAccessStream()` in `IconHelper.CreateBitmapImageAsync`.
🎯 Why: The original implementation copied the byte array into a new buffer inside `InMemoryRandomAccessStream` using `DataWriter`, incurring unnecessary allocation and CPU overhead. The new implementation wraps the existing byte array directly.
📊 Impact: Reduces memory allocations and CPU usage for each icon loaded, improving overall scrolling and loading performance in the main list view.
🔬 Measurement: Verified manually by code inspection and ensuring unit tests pass. Benchmarking would show reduced gen0 allocations.

---
*PR created automatically by Jules for task [17047154439940059820](https://jules.google.com/task/17047154439940059820) started by @mikekthx*