### PR TITLE
🛡️ Sentinel: [HIGH] Prevent NTLM leaks in IconService by blocking UNC paths

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** `IconService.IsUnsafePath` relied on checking `\\` and `//` but missed mixed-slash UNC paths (e.g., `/\attacker` or `\/attacker`), which Windows APIs treat as valid UNC paths, potentially leading to NTLM credential theft.
 **Learning:** `Uri.IsUnc` behavior differs across platforms (Linux vs Windows). On Linux, `Uri` correctly flags `/\` as UNC, but on Windows, it might throw or fail to detect it if malformed, requiring explicit string checks for robust security.
 **Prevention:** Always normalize paths using `Path.GetFullPath` before security checks, and explicitly check for all UNC start patterns (`\\`, `//`, `/\`, `\/`) when dealing with Windows file paths.
+
+## 2025-05-23 - NTLM Leak via Direct UNC Paths
+**Vulnerability:** `IconService.ExtractIconBytes` accepted direct UNC paths, bypassing `ResolveIconPath` checks for `.url` files, potentially leaking NTLM credentials via `GetLastWriteTime` and `PrivateExtractIcons`.
+**Learning:** Input sanitization must be applied at the entry point of public methods (`ExtractIconBytes`), not just in helper methods (`ResolveIconPath`) or specific file types (`.url`).
+**Prevention:** Validate all file paths against `IsUnsafePath` immediately upon entry in `IconService` methods before any file system access.

--- a/Launchbox.Tests/IconServiceSecurityTests.cs
+++ b/Launchbox.Tests/IconServiceSecurityTests.cs
@@ -81,4 +81,22 @@ public class IconServiceSecurityTests
         // Assert
         Assert.Equal(iconPath, result);
     }
+
+    [Fact]
+    public void ExtractIconBytes_BlocksUnsafePaths_PreventsFileSystemAccess()
+    {
+        // Arrange
+        // We use a UNC path that would trigger NTLM auth if accessed
+        string unsafePath = @"\\attacker\share\malicious.lnk";
+
+        // We do NOT add the file to mockFileSystem.
+        // If the code tries to access it (GetLastWriteTime), it might succeed (return default) or fail depending on mock.
+        // But crucially, ExtractIconBytes returns null immediately due to IsUnsafePath check.
+
+        // Act
+        var result = _iconService.ExtractIconBytes(unsafePath);
+
+        // Assert
+        Assert.Null(result);
+    }
 }

--- a/Services/IconService.cs
+++ b/Services/IconService.cs
@@ -90,6 +90,12 @@ public class IconService
 
     public byte[]? ExtractIconBytes(string path)
     {
+        if (IsUnsafePath(path))
+        {
+            Trace.WriteLine($"Blocked icon extraction for unsafe path: {path}");
+            return null;
+        }
+
         // 1. Gather current state (timestamps)
         // We check these every time to support live updates, but avoid expensive operations if unchanged.
 


### PR DESCRIPTION
**Problem:** `IconService.ExtractIconBytes` accepted direct UNC paths, potentially causing NTLM credential leaks when checking for timestamps or extracting system icons.

**Solution:**
- Added a check `if (IsUnsafePath(path)) return null;` at the beginning of `ExtractIconBytes` in `Services/IconService.cs`.
- This ensures unsafe paths are rejected before any file system access (`GetLastWriteTime`, `DirectoryExists`, or `PrivateExtractIcons`).

**Testing:**
- Added `ExtractIconBytes_BlocksUnsafePaths_PreventsFileSystemAccess` test to `Launchbox.Tests/IconServiceSecurityTests.cs`.
- Verified that passing a UNC path returns `null`.
- Ran existing tests and confirmed no regressions (59 passed).

---
*PR created automatically by Jules for task [15528375486516981784](https://jules.google.com/task/15528375486516981784) started by @mikekthx*