### PR TITLE
Sentinel: Prevent INI value truncation in FileSystem

### DIFF
--- a/Services/FileSystem.cs
+++ b/Services/FileSystem.cs
@@ -13,8 +13,27 @@ public class FileSystem : IFileSystem
 
     public string GetIniValue(string path, string section, string key)
     {
-        var sb = new StringBuilder(255);
-        NativeMethods.GetPrivateProfileString(section, key, "", sb, 255, path);
+        // Start with a reasonable buffer size to minimize reallocations
+        int capacity = 512;
+        StringBuilder sb = new StringBuilder(capacity);
+        int ret = NativeMethods.GetPrivateProfileString(section, key, "", sb, capacity, path);
+
+        // Check for truncation. GetPrivateProfileString returns size - 1 (or sometimes size - 2)
+        // if the buffer was too small. We loop to double the buffer size until it fits.
+        while (ret >= capacity - 2)
+        {
+            capacity *= 2;
+            if (capacity > 65536)
+            {
+                // Safety limit to prevent infinite allocation.
+                // If it's larger than 64KB, we accept truncation.
+                break;
+            }
+
+            sb = new StringBuilder(capacity);
+            ret = NativeMethods.GetPrivateProfileString(section, key, "", sb, capacity, path);
+        }
+
         return sb.ToString();
     }
 


### PR DESCRIPTION
This change addresses a potential security and reliability issue where `GetPrivateProfileString` would truncate values longer than 255 characters (the previous fixed buffer size). Truncated paths could lead to incorrect file resolution or security bypasses. The new implementation uses a standard dynamic buffer loop to ensure the full value is read, with a safety cap of 64KB to prevent memory exhaustion.

---
*PR created automatically by Jules for task [17057059608357286021](https://jules.google.com/task/17057059608357286021) started by @mikekthx*