### PR TITLE
🧪 Implement case-insensitive extension filtering in ShortcutService

### DIFF
--- a/Launchbox.Tests/ShortcutServiceTests.cs
+++ b/Launchbox.Tests/ShortcutServiceTests.cs
@@ -42,4 +42,41 @@ public class ShortcutServiceTests
         Assert.Contains(result, f => f.EndsWith("App2.url"));
         Assert.DoesNotContain(result, f => f.EndsWith("App3.txt"));
     }
+
+    [Fact]
+    public void GetShortcutFiles_HandlesCaseInsensitiveExtensions()
+    {
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.AddDirectory(SHORTCUT_FOLDER);
+        mockFileSystem.AddFile(SHORTCUT_FOLDER, "App1.LNK"); // Uppercase extension
+        mockFileSystem.AddFile(SHORTCUT_FOLDER, "App2.URL"); // Uppercase extension
+        mockFileSystem.AddFile(SHORTCUT_FOLDER, "App3.lnk"); // Lowercase extension
+
+        var service = new ShortcutService(mockFileSystem);
+
+        var result = service.GetShortcutFiles(SHORTCUT_FOLDER, ALLOWED_EXTENSIONS);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Length);
+        Assert.Contains(result, f => f.EndsWith("App1.LNK"));
+        Assert.Contains(result, f => f.EndsWith("App2.URL"));
+        Assert.Contains(result, f => f.EndsWith("App3.lnk"));
+    }
+
+    [Fact]
+    public void GetShortcutFiles_HandlesUppercaseAllowedExtensions()
+    {
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.AddDirectory(SHORTCUT_FOLDER);
+        mockFileSystem.AddFile(SHORTCUT_FOLDER, "App1.lnk");
+
+        var service = new ShortcutService(mockFileSystem);
+        var uppercaseExtensions = new[] { ".LNK" };
+
+        var result = service.GetShortcutFiles(SHORTCUT_FOLDER, uppercaseExtensions);
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Contains(result, f => f.EndsWith("App1.lnk"));
+    }
 }

--- a/Services/ShortcutService.cs
+++ b/Services/ShortcutService.cs
@@ -21,7 +21,7 @@ public class ShortcutService
         }
 
         return _fileSystem.GetFiles(folderPath)
-            .Where(f => allowedExtensions.Contains(Path.GetExtension(f).ToLowerInvariant()))
+            .Where(f => allowedExtensions.Contains(Path.GetExtension(f) ?? string.Empty, StringComparer.OrdinalIgnoreCase))
             .OrderBy(f => Path.GetFileName(f))
             .ToArray();
     }


### PR DESCRIPTION
This change improves the reliability of the `ShortcutService` by ensuring that file extension filtering is truly case-insensitive. 

🎯 **What:** The testing gap addressed was the lack of verification for uppercase file extensions (e.g., `App.LNK`) and mixed-case `allowedExtensions` lists.

📊 **Coverage:** 
- Added `GetShortcutFiles_HandlesCaseInsensitiveExtensions` to verify uppercase file extensions are correctly matched against lowercase allowed extensions.
- Added `GetShortcutFiles_HandlesUppercaseAllowedExtensions` to verify that uppercase allowed extensions correctly match lowercase files.

✨ **Result:** The `ShortcutService.GetShortcutFiles` method now uses `StringComparer.OrdinalIgnoreCase` with `Enumerable.Contains`, making it robust against any casing variations in both the files on disk and the configuration of allowed extensions. Logic was verified in the target environment using a standalone reproduction script to confirm the fix works as expected.

---
*PR created automatically by Jules for task [8954305759027806150](https://jules.google.com/task/8954305759027806150) started by @mikekthx*