### PR TITLE
Verify MockFileSystem behavior with long path prefix

### DIFF
--- a/Launchbox.Tests/IconServiceSecurityTests.cs
+++ b/Launchbox.Tests/IconServiceSecurityTests.cs
@@ -66,8 +66,9 @@ public class IconServiceSecurityTests
     {
         // Arrange
         string urlPath = Path.Combine("C:", "Shortcuts", "Long.url");
-        // Note: verify if MockFileSystem handles \\?\ prefix correctly or if Path.Combine creates it.
-        // We will manually construct it.
+
+        // MockFileSystem handles the \\?\ prefix correctly due to its fallback directory parsing logic.
+        // Path.Combine does not automatically add this prefix, so we construct it manually.
         string iconPath = @"\\?\C:\Very\Long\Path\To\Icon.ico";
 
         _mockFileSystem.AddFile(urlPath);


### PR DESCRIPTION
Investigation confirmed that MockFileSystem handles the \\?\ prefix correctly due to its fallback directory parsing logic, and that Path.Combine does not automatically add this prefix. Updated the test documentation in IconServiceSecurityTests.cs to reflect these findings.

---
*PR created automatically by Jules for task [5307551473513094858](https://jules.google.com/task/5307551473513094858) started by @mikekthx*