### PR TITLE
🧹 Remove unused System.Linq import from MainViewModel

### DIFF
--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using System.ComponentModel;


### PR DESCRIPTION
This change removes an unused `using System.Linq;` import from `ViewModels/MainViewModel.cs`. 

- **What:** Removed unused `System.Linq` import.
- **Why:** To improve code maintainability and readability by removing dead code.
- **Verification:** Manually scanned the file for Linq usages; confirmed none are present. Attempted to run the test suite, though it timed out in the current environment.
- **Result:** Cleaned up `MainViewModel.cs`.

---
*PR created automatically by Jules for task [8386155038781286929](https://jules.google.com/task/8386155038781286929) started by @mikekthx*