### PR TITLE
test: MergeItemOrders case-insensitive path lookup regression test

### DIFF
--- a/Launchbox.Tests/SettingsServiceTests.cs
+++ b/Launchbox.Tests/SettingsServiceTests.cs
@@ -264,6 +264,27 @@ public class SettingsServiceTests
     }
 
     [Fact]
+    public void MergeItemOrders_CaseInsensitivePathLookup()
+    {
+        // Regression: MergeItemOrders used a case-sensitive dictionary so a casing mismatch
+        // between sessions caused the persisted order to be silently lost.
+        var store = new MockSettingsStore();
+        var svc = new SettingsService(
+            store,
+            new MockStartupService(),
+            new ShortcutFolderManager(new MockSettingsStore()));
+
+        svc.MergeItemOrders(new Dictionary<string, List<string>>
+        {
+            [@"C:\Foo\Bar"] = ["Alpha.lnk", "Beta.lnk"],
+        });
+
+        // Retrieve with different casing — must find the persisted order
+        var order = svc.GetItemOrder(@"c:\foo\bar");
+        Assert.NotEmpty(order);
+    }
+
+    [Fact]
     public void MergeItemOrders_PreservesAbsentFolderOrders()
     {
         var store = new MockSettingsStore();

--- a/Launchbox.Tests/SettingsServiceTests.cs
+++ b/Launchbox.Tests/SettingsServiceTests.cs
@@ -281,7 +281,7 @@ public class SettingsServiceTests
 
         // Retrieve with different casing — must find the persisted order
         var order = svc.GetItemOrder(@"c:\foo\bar");
-        Assert.NotEmpty(order);
+        Assert.Equal(["Alpha.lnk", "Beta.lnk"], order);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #316

## Summary

- Adds `MergeItemOrders_CaseInsensitivePathLookup` to `SettingsServiceTests.cs`
- Calls `MergeItemOrders` with `C:\Foo\Bar`, then asserts `GetItemOrder(@"c:\foo\bar")` returns non-empty
- Guards against future regressions where a case-sensitive dictionary in `DeserializeItemOrders` silently drops persisted order when folder path casing differs between sessions

The two existing case-insensitive tests (`GetItemOrder_ReturnsCaseInsensitiveMatch` and `GetItemOrder_ReturnsCaseInsensitiveMatch_AfterRoundTrip`) cover `SetItemOrder` — this test covers the `MergeItemOrders` path specifically, as called out in #316.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~MergeItemOrders_CaseInsensitivePathLookup"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)