### PR TITLE
feat: add CycloneDX SBOM generation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
       # Generate a CycloneDX SBOM scoped to NuGet transitive dependencies
       - name: Generate SBOM
         run: |
-          dotnet tool install --global CycloneDX --version 6.1.1
+          dotnet tool update --global CycloneDX --version 6.1.1
           dotnet CycloneDX $env:Project_Path --json --out sbom-output
           Rename-Item -Path sbom-output\bom.json -NewName launchbox-sbom.cdx.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,12 +89,23 @@ jobs:
         with:
           subject-path: AppPackages/**/*.msixbundle
 
+      - name: Cache dotnet global tools
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ~/.dotnet/tools
+          key: ${{ runner.os }}-dotnet-tools-cyclonedx-6.1.1
+
       # Generate a CycloneDX SBOM scoped to NuGet transitive dependencies
       - name: Generate SBOM
         run: |
           dotnet tool install --global CycloneDX --version 6.1.1
           dotnet CycloneDX $env:Project_Path --json --out sbom-output
           Rename-Item -Path sbom-output\bom.json -NewName launchbox-sbom.cdx.json
+
+      - name: Attest SBOM
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: sbom-output/launchbox-sbom.cdx.json
 
       - name: Create GitHub Release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
       # Generate a CycloneDX SBOM scoped to NuGet transitive dependencies
       - name: Generate SBOM
         run: |
-          dotnet tool install --global CycloneDX
+          dotnet tool install --global CycloneDX --version 6.1.1
           dotnet CycloneDX $env:Project_Path --json --out sbom-output
           Rename-Item -Path sbom-output\bom.json -NewName launchbox-sbom.cdx.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,11 +89,18 @@ jobs:
         with:
           subject-path: AppPackages/**/*.msixbundle
 
+      # Generate a CycloneDX SBOM scoped to NuGet transitive dependencies
+      - name: Generate SBOM
+        run: |
+          dotnet tool install --global CycloneDX
+          dotnet CycloneDX $env:Project_Path --json --out sbom-output
+          Rename-Item -Path sbom-output\bom.json -NewName launchbox-sbom.cdx.json
+
       - name: Create GitHub Release
         run: |
           $bundle = Get-ChildItem -Recurse AppPackages -Filter "*.msixbundle" | Select-Object -First 1
           if (-not $bundle) { Write-Error "No .msixbundle found in AppPackages"; exit 1 }
-          $releaseArgs = @("${{ github.ref_name }}", "--title", "${{ github.ref_name }}", "--generate-notes", $bundle.FullName)
+          $releaseArgs = @("${{ github.ref_name }}", "--title", "${{ github.ref_name }}", "--generate-notes", $bundle.FullName, "sbom-output\launchbox-sbom.cdx.json")
           if ("${{ github.ref_name }}" -match '-') { $releaseArgs += "--prerelease" }
           gh release create @releaseArgs
         env:


### PR DESCRIPTION
Closes #293

## Summary

- Installs `dotnet-CycloneDX` (the .NET-native CycloneDX tool) during the release job
- Runs `dotnet CycloneDX` against `Launchbox.csproj` to produce a CycloneDX JSON SBOM covering NuGet transitive dependencies
- Attaches `launchbox-sbom.cdx.json` as a release asset alongside the `.msixbundle` via `gh release create`
- Runs only in `release.yml` (tag-triggered) — never on PR or push-to-main CI

## Acceptance criteria
- [x] SBOM generated automatically on every tagged release
- [x] Attached as a release asset (`launchbox-sbom.cdx.json`)
- [x] Covers NuGet transitive dependencies (dotnet-CycloneDX walks the full dependency graph)
- [x] Does not run on PR or push-to-main CI — scoped to `release.yml` only

## Test plan
- [ ] Push a test tag and verify `launchbox-sbom.cdx.json` appears as a release asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)