### PR TITLE
fix: catch resolver exceptions in WinUILauncher (#332)

### DIFF
--- a/Launchbox.Tests/WinUILauncherExceptionTests.cs
+++ b/Launchbox.Tests/WinUILauncherExceptionTests.cs
@@ -28,6 +28,28 @@ public class WinUILauncherExceptionTests
         }
     }
 
+    private class ThrowingShortcutResolver : IShortcutResolver
+    {
+        public bool WasInvoked { get; private set; }
+
+        public ShortcutMetadata? Resolve(string shortcutPath)
+        {
+            WasInvoked = true;
+            throw new InvalidOperationException("Simulated COM failure");
+        }
+    }
+
+    private class NeverCalledProcessStarter : IProcessStarter
+    {
+        public bool WasInvoked { get; private set; }
+
+        public Process? Start(ProcessStartInfo startInfo)
+        {
+            WasInvoked = true;
+            return null;
+        }
+    }
+
     [Fact]
     public void Constructor_ThrowsArgumentNullException_ForNullShortcutResolver()
     {
@@ -73,5 +95,21 @@ public class WinUILauncherExceptionTests
         var exception = Record.Exception(() => launcher.OpenFolder(@"C:\safe\folder"));
 
         Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Launch_ResolverThrows_DoesNotPropagateAndDoesNotStartProcess()
+    {
+        var throwingResolver = new ThrowingShortcutResolver();
+        var trackingStarter = new NeverCalledProcessStarter();
+        var launcher = new WinUILauncher(throwingResolver, trackingStarter, _fileSystem);
+
+        _fileSystem.AddFile(@"C:\safe\shortcut.lnk");
+
+        var exception = Record.Exception(() => launcher.Launch(@"C:\safe\shortcut.lnk"));
+
+        Assert.Null(exception);
+        Assert.True(throwingResolver.WasInvoked);
+        Assert.False(trackingStarter.WasInvoked);
     }
 }

--- a/Services/WinUILauncher.cs
+++ b/Services/WinUILauncher.cs
@@ -52,6 +52,8 @@ public class WinUILauncher : IAppLauncher
             }
             catch (Exception ex)
             {
+                // Fail closed: a malformed .lnk can cause COM to throw during resolution.
+                // Return early so one bad shortcut doesn't crash the launcher.
                 // Fail closed: treat any resolver exception (e.g. COM failure on a malformed .lnk)
                 // as unresolvable metadata so one bad shortcut doesn't crash the launcher.
                 Trace.WriteLine($"Blocked execution: resolver threw for {PathSecurity.RedactPath(path)}: {PathSecurity.GetSafeExceptionMessage(ex)}");

--- a/Services/WinUILauncher.cs
+++ b/Services/WinUILauncher.cs
@@ -45,7 +45,18 @@ public class WinUILauncher : IAppLauncher
         // Validate shortcut target (Defense-in-depth)
         if (extension == ".lnk" || extension == ".url")
         {
-            var metadata = _shortcutResolver.Resolve(path);
+            ShortcutMetadata? metadata;
+            try
+            {
+                metadata = _shortcutResolver.Resolve(path);
+            }
+            catch (Exception ex)
+            {
+                // Fail closed: treat any resolver exception (e.g. COM failure on a malformed .lnk)
+                // as unresolvable metadata so one bad shortcut doesn't crash the launcher.
+                Trace.WriteLine($"Blocked execution: resolver threw for {PathSecurity.RedactPath(path)}: {PathSecurity.GetSafeExceptionMessage(ex)}");
+                return;
+            }
 
             // Security: fail closed if the resolver could not produce metadata at all
             // (COM failure, buffer truncation, non-Windows platform, or exception).

--- a/Services/WinUILauncher.cs
+++ b/Services/WinUILauncher.cs
@@ -54,8 +54,6 @@ public class WinUILauncher : IAppLauncher
             {
                 // Fail closed: a malformed .lnk can cause COM to throw during resolution.
                 // Return early so one bad shortcut doesn't crash the launcher.
-                // Fail closed: treat any resolver exception (e.g. COM failure on a malformed .lnk)
-                // as unresolvable metadata so one bad shortcut doesn't crash the launcher.
                 Trace.WriteLine($"Blocked execution: resolver threw for {PathSecurity.RedactPath(path)}: {PathSecurity.GetSafeExceptionMessage(ex)}");
                 return;
             }


### PR DESCRIPTION
## Summary

- `IShortcutResolver.Resolve()` was called outside any `try/catch` in `WinUILauncher.Launch()`. A COM failure on a malformed `.lnk` file would propagate uncaught, crashing the launcher instead of failing closed.
- Fix wraps the `Resolve()` call in a dedicated `try/catch` that logs and returns early, consistent with the existing `null`-result path.
- Adds `WinUILauncherExceptionTests.Launch_ResolverThrows_DoesNotPropagateAndDoesNotStartProcess` to assert the exception never escapes and `IProcessStarter` is never invoked.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~WinUILauncherExceptionTests"` — 6 passed
- [x] `dotnet format Launchbox.sln` — no changes

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)