### PR TITLE
test: add missing coverage for watcher reload, stale load race, env-var UNC, and startup-unsupported revert (#333-#336)

### DIFF
--- a/Launchbox.Tests/MainViewModelConcurrencyTests.cs
+++ b/Launchbox.Tests/MainViewModelConcurrencyTests.cs
@@ -82,11 +82,13 @@ public class MainViewModelConcurrencyTests
         {
             if (Interlocked.Increment(ref _callCount) == 1)
             {
-                // Signal that we're about to block, then wait without observing cancellation.
+                // Signal that we're about to block, then wait without observing the load's cancellation token.
                 // The point of this test is that the CTS is cancelled WHILE we're blocked, and
                 // ct.ThrowIfCancellationRequested() after we unblock discards our results.
+                // TestContext.Current.CancellationToken is orthogonal — it lets the test runner reclaim
+                // this thread-pool thread on timeout without affecting the race the test is modelling.
                 BlockingStarted.TrySetResult();
-                _gate.Wait();
+                _gate.Wait(TestContext.Current.CancellationToken);
                 return _blockedCallFiles;
             }
             return _fastCallFiles;

--- a/Launchbox.Tests/MainViewModelConcurrencyTests.cs
+++ b/Launchbox.Tests/MainViewModelConcurrencyTests.cs
@@ -1,0 +1,131 @@
+using Launchbox.Helpers;
+using Launchbox.Services;
+using Launchbox.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Launchbox.Tests;
+
+[Collection("Localization")]
+public class MainViewModelConcurrencyTests
+{
+    private readonly MockFileSystem _fileSystem;
+    private readonly MockIconService _iconService;
+    private readonly MockImageFactory _imageFactory;
+    private readonly MockDispatcher _dispatcher;
+    private readonly MockAppLauncher _appLauncher;
+    private readonly SettingsService _settingsService;
+    private readonly MockWindowService _windowService;
+    private readonly MockSettingsStore _settingsStore;
+    private readonly string _shortcutFolder = Path.Combine("C:", "Shortcuts");
+
+    public MainViewModelConcurrencyTests()
+    {
+        _fileSystem = new MockFileSystem();
+        _iconService = new MockIconService();
+        _imageFactory = new MockImageFactory();
+        _dispatcher = new MockDispatcher();
+        _appLauncher = new MockAppLauncher();
+        _windowService = new MockWindowService();
+        _settingsStore = new MockSettingsStore();
+        _settingsStore.SetValue("ShortcutsPath", _shortcutFolder);
+        _settingsService = new SettingsService(_settingsStore, new MockStartupService(), new ShortcutFolderManager(_settingsStore));
+        _fileSystem.CreateDirectory(_shortcutFolder);
+
+        Localization.SetProvider(new MockStringProvider(new()
+        {
+            { "TrayMenu_Hide", "Hide" },
+            { "TrayMenu_Show", "Show" },
+            { "TrayMenu_Settings", "Settings" },
+            { "TrayMenu_Exit", "Exit" },
+            { "Tray_TooltipFormat", "Launchbox ({0})" },
+            { "Tray_AutomationName", "Launchbox System Tray Icon" },
+            { "Error_NotificationTitle", "Launchbox Error" },
+            { "Modifier_Alt", "Alt" },
+            { "Modifier_Ctrl", "Ctrl" },
+            { "Modifier_Shift", "Shift" },
+            { "Modifier_Win", "Win" },
+        }));
+    }
+
+    private MainViewModel CreateViewModel(IShortcutService shortcutService) =>
+        new(shortcutService, _iconService, _imageFactory, _dispatcher,
+            _appLauncher, _fileSystem, _settingsService, _windowService);
+
+    /// <summary>
+    /// Shortcut service that blocks the first call on a semaphore gate,
+    /// allowing tests to verify that a stale (superseded) load cannot overwrite
+    /// a newer completed load.
+    /// </summary>
+    private sealed class GatedShortcutService : IShortcutService
+    {
+        private readonly SemaphoreSlim _gate;
+        private readonly string[] _blockedCallFiles;
+        private readonly string[] _fastCallFiles;
+        private int _callCount;
+
+        /// <summary>Signals when the first (blocking) call has started waiting on the gate.</summary>
+        public TaskCompletionSource BlockingStarted { get; } = new();
+
+        public GatedShortcutService(SemaphoreSlim gate, string[] blockedCallFiles, string[] fastCallFiles)
+        {
+            _gate = gate;
+            _blockedCallFiles = blockedCallFiles;
+            _fastCallFiles = fastCallFiles;
+        }
+
+        public string[]? GetShortcutFiles(string folderPath, IReadOnlyList<string> allowedExtensions, CancellationToken ct = default)
+        {
+            if (Interlocked.Increment(ref _callCount) == 1)
+            {
+                // Signal that we're about to block, then wait without observing cancellation.
+                // The point of this test is that the CTS is cancelled WHILE we're blocked, and
+                // ct.ThrowIfCancellationRequested() after we unblock discards our results.
+                BlockingStarted.TrySetResult();
+                _gate.Wait();
+                return _blockedCallFiles;
+            }
+            return _fastCallFiles;
+        }
+    }
+
+    [Fact]
+    public async Task LoadAppsAsync_SupersededLoad_CannotOverwriteNewerUIState()
+    {
+        var gate = new SemaphoreSlim(0, 1);
+        var gatedService = new GatedShortcutService(
+            gate,
+            blockedCallFiles: [$@"{_shortcutFolder}\Stale.lnk"],
+            fastCallFiles: [$@"{_shortcutFolder}\Fresh.lnk"]);
+
+        _fileSystem.AddFile($@"{_shortcutFolder}\Stale.lnk");
+        _fileSystem.AddFile($@"{_shortcutFolder}\Fresh.lnk");
+
+        var vm = CreateViewModel(gatedService);
+
+        // Start Load #1 — it will block inside Task.Run waiting on the gate
+        var load1 = vm.LoadAppsAsync();
+
+        // Wait until Load #1 is actually blocking before firing Load #2
+        await gatedService.BlockingStarted.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+
+        // Load #2 fires — this cancels Load #1's CTS and completes with the fresh file
+        await vm.LoadAppsAsync();
+
+        // Assert: UI reflects Load #2's result while Load #1 is still blocked
+        Assert.Single(vm.FilteredApps);
+        Assert.Equal("Fresh", vm.FilteredApps[0].Name);
+
+        // Release Load #1's gate — it will unblock, then hit ct.ThrowIfCancellationRequested()
+        gate.Release();
+        await load1;
+
+        // Assert: stale Load #1 result did not overwrite Load #2's UI state
+        Assert.Single(vm.FilteredApps);
+        Assert.Equal("Fresh", vm.FilteredApps[0].Name);
+    }
+}

--- a/Launchbox.Tests/MainViewModelConcurrencyTests.cs
+++ b/Launchbox.Tests/MainViewModelConcurrencyTests.cs
@@ -56,11 +56,9 @@ public class MainViewModelConcurrencyTests
         new(shortcutService, _iconService, _imageFactory, _dispatcher,
             _appLauncher, _fileSystem, _settingsService, _windowService);
 
-    /// <summary>
-    /// Shortcut service that blocks the first call on a semaphore gate,
-    /// allowing tests to verify that a stale (superseded) load cannot overwrite
-    /// a newer completed load.
-    /// </summary>
+    // Shortcut service that blocks the first call on a semaphore gate,
+    // allowing tests to verify that a stale (superseded) load cannot overwrite
+    // a newer completed load.
     private sealed class GatedShortcutService : IShortcutService
     {
         private readonly SemaphoreSlim _gate;
@@ -68,7 +66,7 @@ public class MainViewModelConcurrencyTests
         private readonly string[] _fastCallFiles;
         private int _callCount;
 
-        /// <summary>Signals when the first (blocking) call has started waiting on the gate.</summary>
+        // Signals when the first (blocking) call has started waiting on the gate.
         public TaskCompletionSource BlockingStarted { get; } = new();
 
         public GatedShortcutService(SemaphoreSlim gate, string[] blockedCallFiles, string[] fastCallFiles)

--- a/Launchbox.Tests/MainViewModelTests.cs
+++ b/Launchbox.Tests/MainViewModelTests.cs
@@ -962,4 +962,31 @@ public class MainViewModelTests
         Assert.Equal(string.Empty, group[0].Name); // placeholder sentinel
         Assert.Equal(string.Empty, vm.FilterText);
     }
+
+    // --- WATCHER INTEGRATION TESTS ---
+
+    [Fact]
+    public async Task FileWatcherCallback_TriggersReload_AndPicksUpNewFile()
+    {
+        // Arrange: initial load with one file
+        _fileSystem.AddFile(Path.Combine(_shortcutFolder, "Alpha.lnk"));
+        var vm = CreateViewModel();
+        await vm.LoadAppsAsync();
+        Assert.Single(vm.FilteredApps);
+
+        // Add a second file AFTER the initial load so the watcher reload picks it up
+        _fileSystem.AddFile(Path.Combine(_shortcutFolder, "Beta.lnk"));
+
+        var reloadTcs = new TaskCompletionSource();
+        vm.FilteredApps.CollectionChanged += (_, _) => reloadTcs.TrySetResult();
+
+        // Act: simulate a directory change event — fires the registered watcher callback
+        // which calls _ = LoadAppsAsync() internally
+        _fileSystem.SimulateChange(_shortcutFolder);
+
+        await reloadTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+
+        // Assert: both files are visible after the watcher-triggered reload
+        Assert.Equal(2, vm.FilteredApps.Count);
+    }
 }

--- a/Launchbox.Tests/MainViewModelTests.cs
+++ b/Launchbox.Tests/MainViewModelTests.cs
@@ -978,7 +978,12 @@ public class MainViewModelTests
         _fileSystem.AddFile(Path.Combine(_shortcutFolder, "Beta.lnk"));
 
         var reloadTcs = new TaskCompletionSource();
-        vm.FilteredApps.CollectionChanged += (_, _) => reloadTcs.TrySetResult();
+        vm.FilteredApps.CollectionChanged += (_, _) =>
+        {
+            // Guard on Count so a Reset/clear event before the Add does not resolve the TCS early.
+            if (vm.FilteredApps.Count == 2)
+                reloadTcs.TrySetResult();
+        };
 
         // Act: simulate a directory change event — fires the registered watcher callback
         // which calls _ = LoadAppsAsync() internally

--- a/Launchbox.Tests/SettingsViewModelTests.cs
+++ b/Launchbox.Tests/SettingsViewModelTests.cs
@@ -613,6 +613,8 @@ public class SettingsViewModelTests
         var vm = new SettingsViewModel(settingsService, new MockWindowService(), new MockFilePickerService(), new MockDispatcher());
 
         var revertTcs = new TaskCompletionSource();
+        // PropertyChanged for RunAtStartup fires only after the async revert completes, not
+        // optimistically on set — so the first notification here reflects the reverted false value.
         vm.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(SettingsViewModel.RunAtStartup))

--- a/Launchbox.Tests/SettingsViewModelTests.cs
+++ b/Launchbox.Tests/SettingsViewModelTests.cs
@@ -601,4 +601,29 @@ public class SettingsViewModelTests
         Assert.Equal("OldLabel", vm.Folders[0].Label);
     }
 
+    [Fact]
+    public async Task RunAtStartup_WhenStartupServiceUnsupported_RevertsToFalse()
+    {
+        // When IsSupported is false, SetRunAtStartupAsync returns early without changing
+        // IsRunAtStartup. The ViewModel should revert _pendingStartupValue to match the
+        // committed state (false), so the toggle does not appear stuck in the requested state.
+        var store = new MockSettingsStore();
+        var startupService = new MockStartupService { IsSupported = false };
+        var settingsService = new SettingsService(store, startupService, new ShortcutFolderManager(store));
+        var vm = new SettingsViewModel(settingsService, new MockWindowService(), new MockFilePickerService(), new MockDispatcher());
+
+        var revertTcs = new TaskCompletionSource();
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(SettingsViewModel.RunAtStartup))
+                revertTcs.TrySetResult();
+        };
+
+        vm.RunAtStartup = true;
+
+        await revertTcs.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+
+        Assert.False(vm.RunAtStartup);
+        Assert.False(startupService.IsEnabled);
+    }
 }

--- a/Launchbox.Tests/ShortcutFolderManagerTests.cs
+++ b/Launchbox.Tests/ShortcutFolderManagerTests.cs
@@ -603,4 +603,28 @@ public class ShortcutFolderManagerTests
         Assert.False(string.IsNullOrEmpty(folders[0].Label));
         Assert.Equal(@"C:\", folders[0].Label);
     }
+
+    [Fact]
+    public void AddFolder_EnvVarThatExpandsToUncPath_IsRejected()
+    {
+        // An env var whose expansion yields a UNC path bypasses a naive path check.
+        // ShortcutFolderManager must expand the variable before validating.
+        const string envVar = "LAUNCHBOX_TEST_UNC_PATH";
+        Environment.SetEnvironmentVariable(envVar, @"\\attacker\share");
+        try
+        {
+            var store = new MockSettingsStore();
+            var manager = new ShortcutFolderManager(store);
+
+            var result = manager.AddFolder($@"%{envVar}%\Apps", "Bad");
+
+            Assert.False(result);
+            // Store must not have been updated with the unsafe path
+            Assert.DoesNotContain(manager.GetFolders(), f => f.Path.Contains(envVar));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVar, null);
+        }
+    }
 }

--- a/Launchbox.Tests/ShortcutFolderManagerTests.cs
+++ b/Launchbox.Tests/ShortcutFolderManagerTests.cs
@@ -619,8 +619,8 @@ public class ShortcutFolderManagerTests
             var result = manager.AddFolder($@"%{envVar}%\Apps", "Bad");
 
             Assert.False(result);
-            // Store must not have been updated with the unsafe path
-            Assert.DoesNotContain(manager.GetFolders(), f => f.Path.Contains(envVar));
+            // Store must not have been updated with either the raw env-var form or the expanded UNC path
+            Assert.DoesNotContain(manager.GetFolders(), f => f.Path.Contains(envVar) || f.Path.Contains(@"\\attacker\share"));
         }
         finally
         {


### PR DESCRIPTION
## Summary

Adds four missing tests that were called out as test gaps in issues #333–#336. No production code changes.

- **#333** `FileWatcherCallback_TriggersReload_AndPicksUpNewFile` — simulates a directory change event via `MockFileSystem.SimulateChange()` and asserts the watcher callback triggers a full reload that picks up newly added files, using `FilteredApps.CollectionChanged` as the completion signal.

- **#334** `LoadAppsAsync_SupersededLoad_CannotOverwriteNewerUIState` — uses a new `GatedShortcutService` helper (inline class) that blocks the first scanning call on a semaphore. Fires two loads, lets the second complete with a "Fresh" file, then releases the gate on the first. Asserts the stale first load's results never appear in `FilteredApps` after `ct.ThrowIfCancellationRequested()` discards them.

- **#335** `AddFolder_EnvVarThatExpandsToUncPath_IsRejected` — sets a temp env var to `\attacker\share`, calls `AddFolder` with `%VAR%\Apps`, asserts the call returns false and no folder is persisted.

- **#336** `RunAtStartup_WhenStartupServiceUnsupported_RevertsToFalse` — sets `MockStartupService.IsSupported = false`, sets `vm.RunAtStartup = true`, waits for `PropertyChanged`, asserts `vm.RunAtStartup == false` and the service was never enabled.

## Test plan

- [x] New tests: all 4 pass
- [x] Full suite: 504 passed, 0 failed
- [x] `dotnet format Launchbox.sln` — no changes

Closes #333
Closes #334
Closes #335
Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)