### PR TITLE
ci: workflow hygiene — timeouts, RUNNER_TEMP PFX, comment fix

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,7 @@ jobs:
     # so the OAuth token would be empty. Skip review — SHA bumps don't need it.
     if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,7 @@ jobs:
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -20,6 +20,7 @@ jobs:
   analyze:
     name: Security Scan (CodeQL)
     runs-on: windows-latest
+    timeout-minutes: 15
     concurrency:
       group: ${{ github.workflow }}-analyze-${{ github.ref }}
       cancel-in-progress: true
@@ -39,6 +40,8 @@ jobs:
   build:
     # Skip build/test on scheduled runs — schedule is for CodeQL only
     if: github.event_name != 'schedule'
+
+    timeout-minutes: 20
 
     concurrency:
       group: ${{ github.workflow }}-build-${{ github.ref }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,7 @@ jobs:
       pull-requests: write
       issues: write
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Apply PR Labels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ jobs:
   release:
     name: Build, Submit, and Draft Release
     runs-on: windows-latest
+    timeout-minutes: 60
 
     env:
       Solution_Name: Launchbox.sln
-      Project_Directory: .
       Project_Path: Launchbox.csproj
       Test_Project_Path: Launchbox.Tests\Launchbox.Tests.csproj
 
@@ -131,7 +131,9 @@ jobs:
       - name: Decode and install the pfx
         run: |
           $pfx_cert_byte = [System.Convert]::FromBase64String($env:BASE64_PFX)
-          $certificatePath = Join-Path -Path $env:Project_Directory -ChildPath GitHubActionsWorkflow.pfx
+          $certificatePath = Join-Path -Path $env:RUNNER_TEMP -ChildPath GitHubActionsWorkflow.pfx
+          # Write path immediately so cleanup step can find the file even if later steps fail
+          echo "PFX_PATH=$certificatePath" >> $env:GITHUB_ENV
           [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
           $pwd = ConvertTo-SecureString -String $env:PFX_KEY -Force -AsPlainText
           $cert = Import-PfxCertificate -FilePath "$certificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $pwd
@@ -157,7 +159,7 @@ jobs:
       - name: Remove pfx and cert
         if: always()
         run: |
-          Remove-Item -Path $env:Project_Directory\GitHubActionsWorkflow.pfx -ErrorAction SilentlyContinue
+          Remove-Item -Path "$env:PFX_PATH" -ErrorAction SilentlyContinue
           if ($env:CERT_THUMBPRINT) {
             Get-ChildItem Cert:\CurrentUser\My\$env:CERT_THUMBPRINT -ErrorAction SilentlyContinue | Remove-Item
           }

--- a/.github/workflows/store-sync.yml
+++ b/.github/workflows/store-sync.yml
@@ -1,6 +1,6 @@
 name: Store Sync
 
-# Polls the Microsoft Store every 6 hours and publishes the matching draft GitHub Release
+# Polls the Microsoft Store every hour and publishes the matching draft GitHub Release
 # once the submitted version is certified. Can also be triggered manually.
 on:
   schedule:
@@ -18,6 +18,7 @@ jobs:
   sync:
     name: Publish Draft When Store Certifies
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Check Store certification and publish draft release


### PR DESCRIPTION
## Summary

- **Add `timeout-minutes` to all 7 workflow jobs** — prevents runaway or hung jobs from consuming unlimited runner time. Values chosen with headroom over observed run times: analyze (15 min), build (20 min), release (60 min), store-sync (10 min), dependency-review (10 min), triage (5 min), claude (15 min), claude-review (20 min).
- **Move PFX signing cert out of workspace into `RUNNER_TEMP`** (`release.yml`) — the workspace root is inside `$GITHUB_WORKSPACE`, which can be swept into artifacts by mistake. `RUNNER_TEMP` is runner-managed and outside the checkout tree. `PFX_PATH` is written to `GITHUB_ENV` immediately after the path is computed (before any fallible operation) so the `if: always()` cleanup step can find and delete the file even if later steps in the job fail.
- **Remove dead `Project_Directory` env var** (`release.yml`) — was only used for the PFX path, now replaced by `RUNNER_TEMP`.
- **Fix stale comment in `store-sync.yml`** — said "every 6 hours" but the cron expression `0 * * * *` fires every hour.

## Test plan

- [ ] CI on this PR exercises the `build` and `analyze` jobs — verify both complete under their new timeouts
- [ ] `release.yml` changes are syntax-only (path + env var); verify next release run writes and cleans up the PFX from `RUNNER_TEMP`
- [ ] No functional changes to any workflow logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)