### PR TITLE
Add SECURITY.md and CONTRIBUTING.md to improve OpenSSF score

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Launchbox
+
+## Prerequisites
+
+- Windows 10 or 11 (WinUI 3 requires Windows)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- Visual Studio 2022 (17.x) with the **Windows App SDK** workload, or the `dotnet` CLI
+
+## Building and testing
+
+```bash
+# Build (Debug, x64)
+dotnet build Launchbox.csproj -p:Platform=x64
+
+# Run unit tests
+dotnet test Launchbox.Tests/Launchbox.Tests.csproj
+
+# Format code (required before committing)
+dotnet format Launchbox.sln
+```
+
+CI enforces `dotnet format --verify-no-changes` on every push; run `dotnet format Launchbox.sln` locally first to avoid a failed check.
+
+## Pull request process
+
+1. Branch off `main` with a descriptive name.
+2. All CI checks must pass: build, unit tests, CodeQL, and ≥ 80% line coverage.
+3. At least one CODEOWNER review is required before merge.
+4. Signed commits are strongly preferred (`git config commit.gpgsign true`).
+
+## Code style
+
+- 4-space indentation for C#, 2-space for XAML/XML — enforced by `.editorconfig`.
+- Nullable reference types are enabled; use the `?` suffix.
+- Follow the naming conventions and patterns documented in [`CLAUDE.md`](../CLAUDE.md).
+
+## Adding tests
+
+- New testable classes must be file-linked in `Launchbox.Tests/Launchbox.Tests.csproj` (see the existing `<Compile Include>` entries).
+- Use the existing mock classes (`MockFileSystem`, `MockSettingsStore`, etc.) where possible.
+- The 80% coverage threshold is enforced by CI and will block merge if not met.
+
+## Security
+
+Do not open public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the private reporting process.
+
+## Commit messages
+
+Use imperative mood in the present tense ("Add feature", not "Added feature"). Reference issue numbers where applicable: `Fixes #123`.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -14,7 +14,7 @@ Only the latest release receives security fixes.
 **Do not open a public issue for security vulnerabilities.**
 
 Use GitHub's private vulnerability reporting:
-👉 [Report a vulnerability](../../security/advisories/new)
+👉 [Report a vulnerability](https://github.com/mikekthx/Launchbox/security/advisories/new)
 
 We will acknowledge the report within **48 hours** and aim to release a patch within **14 days** for critical issues.
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅        |
+| older   | ❌        |
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Use GitHub's private vulnerability reporting:
+👉 [Report a vulnerability](../../security/advisories/new)
+
+We will acknowledge the report within **48 hours** and aim to release a patch within **14 days** for critical issues.
+
+## Disclosure Policy
+
+We follow coordinated disclosure. Please allow us to patch and publish a release before any public disclosure. We will credit reporters in the release notes unless anonymity is requested.


### PR DESCRIPTION
## Summary

- Adds `.github/SECURITY.md` with a vulnerability disclosure policy and private reporting link — satisfies the OpenSSF Scorecard **Security-Policy** check (currently 0/10, moves to 10/10)
- Adds `.github/CONTRIBUTING.md` covering build setup, code style, test requirements, commit conventions, and the PR process — satisfies the **CII-Best-Practices** contributing-process criterion

## Closes

Closes #374
Closes #377

## Test plan

- [ ] Verify CI passes (dotnet format, build, tests — these are Markdown-only changes so no code impact)
- [ ] After merge, trigger the Scorecard workflow manually (Actions → Scorecard analysis → Run workflow) and confirm the Security-Policy finding resolves in the Security tab
- [ ] Confirm GitHub shows the green "Security policy" checkmark in the Security tab

https://claude.ai/code/session_01QzD53ZQtq7sQ8niJpkBxBv