### PR TITLE
ci: tighten workflow token permissions for scorecard

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "cyclonedx": {
+      "version": "6.1.1",
+      "commands": [
+        "dotnet-CycloneDX"
+      ]
+    }
+  }
+}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+permissions: read-all
+
 jobs:
   claude-review:
     # Dependabot PRs cannot access repository secrets (GitHub security restriction),

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.CLAUDE_PAT }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.comment.id || github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   claude:
     # Gate to repo owner only — this job checks out with a PAT and has write access

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   dependency-review:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,7 +9,7 @@ on:
       - 'global.json'
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,7 +9,7 @@ on:
       - 'global.json'
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,72 @@
+name: Fuzzing
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    # Weekly run to catch regressions introduced since last release
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  fuzz:
+    name: SharpFuzz
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          global-json-file: global.json
+
+      - name: Build fuzzing target
+        run: dotnet build Fuzz/Fuzz.csproj -c Release
+
+      - name: Run fuzzer against seed corpus
+        shell: bash
+        run: |
+          # Each seed file starts with a tag byte (0-4) that selects the target,
+          # followed by the payload. SharpFuzz replays them as single-shot runs.
+
+          # 0 — ContainsUncPath: UNC patterns and safe URLs
+          printf '\x00\\\\server\\share'                    > /tmp/s0a
+          printf '\x00//server/share'                       > /tmp/s0b
+          printf '\x00https://example.com/path'             > /tmp/s0c
+          printf '\x00ftp://example.com'                    > /tmp/s0d
+
+          # 1 — IsUnsafePath: local drive, UNC, extended-length, NT object path
+          printf '\x01C:\\Users\\file.txt'                  > /tmp/s1a
+          printf '\x01\\\\server\\share'                    > /tmp/s1b
+          printf '\x01\\\\?\\C:\\long\\path\\file.txt'      > /tmp/s1c
+          printf '\x01\\??\\device\\null'                   > /tmp/s1d
+
+          # 2 — RedactPath: paths with and without separators
+          printf '\x02C:\\Users\\secret\\file.txt'          > /tmp/s2a
+          printf '\x02just-a-filename.txt'                  > /tmp/s2b
+          printf '\x02C:\\'                                 > /tmp/s2c
+
+          # 3 — GetPngDimensions: valid header, truncated, garbage
+          printf '\x03\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x10\x00\x00\x00\x10' > /tmp/s3a
+          printf '\x03\x89PNG\r\n'                          > /tmp/s3b
+          printf '\x03\xff\xff\xff\xff'                     > /tmp/s3c
+
+          # 4 — GetMaxIcoDimensions: valid two-entry header, zero count, garbage
+          printf '\x04\x00\x00\x01\x00\x02\x00\x10\x10\x00\x00\x01\x00\x20\x00\x00\x00\x00\x00\x20\x20\x00\x00\x01\x00\x20\x00\x00\x00\x00\x00' > /tmp/s4a
+          printf '\x04\x00\x00\x01\x00\x00\x00'            > /tmp/s4b
+          printf '\x04\xff\xff\xff\xff\xff\xff'             > /tmp/s4c
+
+          for seed in /tmp/s{0,1,2,3,4}{a,b,c,d}; do
+            [ -f "$seed" ] || continue
+            if ! dotnet run --project Fuzz/Fuzz.csproj -c Release --no-build -- "$seed" 2>&1; then
+              echo "::error::Crash on $(basename "$seed") — $(xxd "$seed" | head -2)"
+              exit 1
+            fi
+          done

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
       - name: Install .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-release-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
+          key: ${{ runner.os }}-nuget-release-${{ hashFiles('**/packages.lock.json', '**/*.csproj', '.config/dotnet-tools.json') }}
           restore-keys: |
             ${{ runner.os }}-nuget-release-
             ${{ runner.os }}-nuget-
@@ -173,16 +173,10 @@ jobs:
         with:
           subject-path: AppPackages/**/*.msixbundle
 
-      - name: Cache dotnet global tools
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.dotnet/tools
-          key: ${{ runner.os }}-dotnet-tools-cyclonedx-6.1.1
-
       - name: Generate SBOM
         run: |
-          dotnet tool update --global CycloneDX --version 6.1.1
-          dotnet CycloneDX $env:Project_Path --json --out sbom-output
+          dotnet tool restore
+          dotnet tool run dotnet-CycloneDX $env:Project_Path --json --out sbom-output
           Rename-Item -Path sbom-output\bom.json -NewName launchbox-sbom.cdx.json
 
       - name: Attest SBOM

--- a/.gitignore
+++ b/.gitignore
@@ -498,7 +498,8 @@ $RECYCLE.BIN/
 
 # AI and Config
 .claude/
-.config/
+.config/*
+!.config/dotnet-tools.json
 .vscode/
 
 # Additional Tools

--- a/Fuzz/Fuzz.csproj
+++ b/Fuzz/Fuzz.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpFuzz" Version="2.1.1" />
+    <PackageReference Include="SharpFuzz" Version="2.2.0" />
   </ItemGroup>
 
   <!--

--- a/Fuzz/Fuzz.csproj
+++ b/Fuzz/Fuzz.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!--
+      Target net10.0 (no -windows suffix) so the fuzzer builds and runs on the
+      Ubuntu CI runner without WinUI/WAS dependencies.
+    -->
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <!-- Match the production namespace so linked files compile without changes. -->
+    <RootNamespace>Launchbox</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SharpFuzz" Version="2.1.1" />
+  </ItemGroup>
+
+  <!--
+    File-link the two pure-logic helpers under test. This mirrors the pattern
+    used by Launchbox.Tests and avoids pulling in the WinUI application host.
+  -->
+  <ItemGroup>
+    <Compile Include="..\Helpers\PathSecurity.cs" Link="Helpers/PathSecurity.cs" />
+    <Compile Include="..\Helpers\ImageHeaderParser.cs" Link="Helpers/ImageHeaderParser.cs" />
+  </ItemGroup>
+</Project>

--- a/Fuzz/Fuzz.csproj
+++ b/Fuzz/Fuzz.csproj
@@ -3,12 +3,13 @@
     <OutputType>Exe</OutputType>
     <!--
       Target net10.0 (no -windows suffix) so the fuzzer builds and runs on the
-      Ubuntu CI runner without WinUI/WAS dependencies.
+      Ubuntu CI runner without WinUI/WAS dependencies. This project is
+      intentionally excluded from Launchbox.sln for the same reason — the
+      Windows solution targets net10.0-windows and cannot build this project.
     -->
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
     <!-- Match the production namespace so linked files compile without changes. -->
     <RootNamespace>Launchbox</RootNamespace>
   </PropertyGroup>

--- a/Fuzz/Program.cs
+++ b/Fuzz/Program.cs
@@ -3,7 +3,7 @@ using SharpFuzz;
 using System.IO;
 using System.Text;
 
-// Single entry point: the first byte selects which code path to exercise so
+// Single entry point: the first byte (mod 5) selects which code path to exercise so
 // one binary covers all five security-sensitive targets. libFuzzer drives
 // input generation; the CI workflow replays a seed corpus for regression.
 Fuzzer.LibFuzzer.Run((ReadOnlySpan<byte> data) =>

--- a/Fuzz/Program.cs
+++ b/Fuzz/Program.cs
@@ -1,36 +1,34 @@
-using System.IO;
-using System.Text;
 using Launchbox.Helpers;
 using SharpFuzz;
+using System.IO;
+using System.Text;
 
 // Single entry point: the first byte selects which code path to exercise so
 // one binary covers all five security-sensitive targets. libFuzzer drives
 // input generation; the CI workflow replays a seed corpus for regression.
-Fuzzer.LibFuzzer.Run(stream =>
+Fuzzer.LibFuzzer.Run((ReadOnlySpan<byte> data) =>
 {
-    if (stream.Length == 0) return;
+    if (data.IsEmpty) return;
 
-    int tag = stream.ReadByte();
-    using var ms = new MemoryStream();
-    stream.CopyTo(ms);
-    byte[] data = ms.ToArray();
+    int tag = data[0];
+    var payload = data[1..];
 
     switch (tag % 5)
     {
         case 0:
-            PathSecurity.ContainsUncPath(Encoding.UTF8.GetString(data));
+            PathSecurity.ContainsUncPath(Encoding.UTF8.GetString(payload));
             break;
         case 1:
-            PathSecurity.IsUnsafePath(Encoding.UTF8.GetString(data));
+            PathSecurity.IsUnsafePath(Encoding.UTF8.GetString(payload));
             break;
         case 2:
-            PathSecurity.RedactPath(Encoding.UTF8.GetString(data));
+            PathSecurity.RedactPath(Encoding.UTF8.GetString(payload));
             break;
         case 3:
-            ImageHeaderParser.GetPngDimensions(new MemoryStream(data));
+            ImageHeaderParser.GetPngDimensions(new MemoryStream(payload.ToArray()));
             break;
         case 4:
-            ImageHeaderParser.GetMaxIcoDimensions(new MemoryStream(data));
+            ImageHeaderParser.GetMaxIcoDimensions(new MemoryStream(payload.ToArray()));
             break;
     }
 });

--- a/Fuzz/Program.cs
+++ b/Fuzz/Program.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Text;
+using Launchbox.Helpers;
+using SharpFuzz;
+
+// Single entry point: the first byte selects which code path to exercise so
+// one binary covers all five security-sensitive targets. libFuzzer drives
+// input generation; the CI workflow replays a seed corpus for regression.
+Fuzzer.LibFuzzer.Run(stream =>
+{
+    if (stream.Length == 0) return;
+
+    int tag = stream.ReadByte();
+    using var ms = new MemoryStream();
+    stream.CopyTo(ms);
+    byte[] data = ms.ToArray();
+
+    switch (tag % 5)
+    {
+        case 0:
+            PathSecurity.ContainsUncPath(Encoding.UTF8.GetString(data));
+            break;
+        case 1:
+            PathSecurity.IsUnsafePath(Encoding.UTF8.GetString(data));
+            break;
+        case 2:
+            PathSecurity.RedactPath(Encoding.UTF8.GetString(data));
+            break;
+        case 3:
+            ImageHeaderParser.GetPngDimensions(new MemoryStream(data));
+            break;
+        case 4:
+            ImageHeaderParser.GetMaxIcoDimensions(new MemoryStream(data));
+            break;
+    }
+});

--- a/Launchbox.csproj
+++ b/Launchbox.csproj
@@ -4,7 +4,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <OutputType>WinExe</OutputType>
     <RootNamespace>Launchbox</RootNamespace>
-    <DefaultItemExcludes>$(DefaultItemExcludes);Launchbox.Tests\**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Launchbox.Tests\**;Fuzz\**</DefaultItemExcludes>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x64;ARM64</Platforms>
     <Platform Condition="'$(Platform)' == '' or '$(Platform)' == 'AnyCPU'">x64</Platform>


### PR DESCRIPTION
Add top-level `permissions: read-all` to claude.yml and
claude-code-review.yml so the GITHUB_TOKEN defaults to read-only
instead of write-all when job-level blocks are the only declaration.
Drop the unused `id-token: write` from dependency-review.yml — neither
the component-detection submission action nor the dependency-review
action requires OIDC.

https://claude.ai/code/session_01CmsHCaKL8SXa7pzUcFPmU4